### PR TITLE
Add option for deleting based on number of clicks

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Mass Remove Links
 Plugin URI: https://github.com/YOURLS/mass-remove-links/
 Description: Remove several (or all) links.
-Version: 1.1
+Version: 1.2
 Author: Ozh
 Author URI: http://ozh.org/
 */
@@ -59,6 +59,12 @@ function ozh_yourls_linkmr_form() {
         <input type="text" name="url" /> (case sensitive)
         </p>
 
+        <p><label for="radio_clicks">
+        <input type="radio" name="what" id="radio_clicks" value="clicks"/>All links with the specified amount of clicks (exact number)
+        </label>
+        <input type="number" name="clicks" value="0" />
+        </p>
+
         <p><label for="radio_all">
         <input type="radio" name="what" id="radio_all" value="all"/>All links. All.
         </label>
@@ -73,7 +79,7 @@ function ozh_yourls_linkmr_form() {
         function select_radio(el){
                 $(el).parent().find(':radio').click();
         }
-        $('input:text')
+        $('input:text, input[type="number"]')
             .click(function(){select_radio($(this))})
             .focus(function(){select_radio($(this))})
             .change(function(){select_radio($(this))});
@@ -91,6 +97,11 @@ function ozh_yourls_linkmr_process() {
     switch( $_POST['what'] ) {
         case 'all':
             $where = '1=1';
+            break;
+
+        case 'clicks':
+            $where = "`clicks` = :clicks";
+            $binds['clicks'] = (int) $_POST['clicks'];
             break;
 
         case 'date':

--- a/plugin.php
+++ b/plugin.php
@@ -60,9 +60,14 @@ function ozh_yourls_linkmr_form() {
         </p>
 
         <p><label for="radio_clicks">
-        <input type="radio" name="what" id="radio_clicks" value="clicks"/>All links with the specified amount of clicks (exact number)
+        <input type="radio" name="what" id="radio_clicks" value="clicks"/>All links with the specified amount of clicks
         </label>
-        <input type="number" name="clicks" value="0" />
+        <select name="clicks_filter">
+            <option value="equals">Equals (=)</option>
+            <option value="greaterThan">Greater than (>)</option>
+            <option value="lessThan">Less than (<)</option>
+        </select>
+        <input type="number" name="clicks" min="0" value="0" />
         </p>
 
         <p><label for="radio_all">
@@ -94,14 +99,22 @@ function ozh_yourls_linkmr_process() {
     $where = '';
     $binds = array();
 
+    $validClicksFilters = array(
+        'equals' => '=',
+        'greaterThan' => '>',
+        'lessThan' => '<',
+    );
+
     switch( $_POST['what'] ) {
         case 'all':
             $where = '1=1';
             break;
 
         case 'clicks':
-            $where = "`clicks` = :clicks";
+            $clicksFilter = $validClicksFilters[$_POST['clicks_filter']] ?? '=';
+
             $binds['clicks'] = (int) $_POST['clicks'];
+            $where = "`clicks` $clicksFilter :clicks";
             break;
 
         case 'date':


### PR DESCRIPTION
Added a field for filtering by links based on number of clicks

I kept it pretty simple and set it to only exact number of clicks. My specific use case for this was to deal with links that have 0 clicks (no more, no less). Though it could probably be extended to support a "minimum" and "maximum" to allow for ranges. (e.g. links with between 1 and 5 clicks).

I also took the liberty of bumping the version from 1.1 to 1.2 :)

Fixes #1