### PR TITLE
Escape output and silence PHP 8 undefined-key warning

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -105,7 +105,7 @@ function ozh_yourls_linkmr_process() {
         'lessThan' => '<',
     );
 
-    switch( $_POST['what'] ) {
+    switch( $_POST['what'] ?? '' ) {
         case 'all':
             $where = '1=1';
             break;
@@ -161,15 +161,18 @@ function ozh_yourls_linkmr_process() {
             echo '<p>'.count( $query ).' found:</p>';
             echo '<ul>';
             foreach( $query as $link ) {
-                $short = $link->keyword;
-                $url   = $link->url;
-                echo "<li>$short: <a href='$url'>$url</a></li>\n";
+                $short = yourls_esc_html( $link->keyword );
+                $url   = yourls_esc_html( $link->url );
+                $href  = yourls_esc_url( $link->url );
+                echo "<li>$short: <a href='$href'>$url</a></li>\n";
             }
             echo '</ul>';
             unset( $_POST['test'] );
             echo '<form method="post">';
             foreach( $_POST as $k=>$v ) {
-                if( $v ) {
+                if( $v && is_scalar( $v ) ) {
+                    $k = yourls_esc_attr( $k );
+                    $v = yourls_esc_attr( $v );
                     echo "<input type='hidden' name='$k' value='$v' />";
                 }
             }


### PR DESCRIPTION
Small set of safety fixes; no behaviour change for valid inputs.

## Changes (`plugin.php`)

- **Escape DB-sourced output** in the test-results listing
  (`yourls_esc_html` for keyword/long URL, `yourls_esc_url` for the
  link `href`). Previously the listing rendered raw `keyword` and
  `url` columns, which can contain user-supplied data.
- **Escape POST data reflected as hidden inputs** in the confirmation
  form, and skip non-scalar values. The previous loop echoed
  `name='$k' value='$v'` straight from `$_POST`, allowing a crafted
  POST body to inject markup.
- **Null-coalesce `$_POST['what']`** in the `switch`. On PHP 8.0+ the
  prior code triggered an "Undefined array key" warning when the form
  was submitted with no radio selected.

No version bump, no API changes, no new dependencies.